### PR TITLE
Update 00-getting-started.ipynb

### DIFF
--- a/samples/notebooks/python/00-getting-started.ipynb
+++ b/samples/notebooks/python/00-getting-started.ipynb
@@ -106,7 +106,7 @@
     "skill = kernel.import_semantic_skill_from_directory(\"../../skills\", \"FunSkill\")\n",
     "joke_function = skill[\"Joke\"]\n",
     "\n",
-    "print(joke_function(\"time travel to dinosaur age\"))"
+    "print(joke_function.invoke(\"time travel to dinosaur age\"))"
    ]
   }
  ],


### PR DESCRIPTION
Fixing the "Object of type "SKFunctionBase" is not callable" error in the example. Using invoke method does the trick.

The sample code was not working because SKFunctionBase is not callable. I added the call to invoke method and it works.